### PR TITLE
fix: correct typo in AppImage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ fwupdmgr update
 ## AppImage
 
 * For Appimage support install fuse:
-* `sudo dnf in fuse-libs`
+* `sudo dnf install fuse-libs`
 * You can also install an AppImage manager like [Gearlever](https://flathub.org/apps/it.mijorus.gearlever) for neater management. To do so, run the following command:
 * `flatpak install it.mijorus.gearlever` 
 


### PR DESCRIPTION

This PR fixes a typo in AppImage section in the fuse install command tp`sudo dnf in fuse-libs`

Closes #57 