### PR TITLE
Remove misleading message about secure boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ Install Nvidia drivers by following the steps below in a terminal:
  * Wait for atleast 5 mins before rebooting, to let the kernel module get built. Once its built, the command above would output the driver version instead of an error.
  * `modinfo -F version nvidia # check if kmod is built` 
  * Reboot once its built.
- * Congrats now you have working nvidia drivers setup with secure boot enabled!
-
 * Congrats now you have working Nvidia drivers!
 </details>
 


### PR DESCRIPTION
Removes a line from the Secure Boot Disabled portion of the NVIDIA Drivers section. The line is redundant with the other congrats message, but more importantly, it implies that by following the driver install instructions, secure boot will now be enabled on your system. I believe this line was simply a copy-paste accident from the Secure Boot Enabled section.